### PR TITLE
Search for default compose files in docker subdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,21 @@ my-project/
 You can now run your docker compose commands with DockerC:
 
 ```sh
-dockerc               # -> docker compose up -d
+# The default context uses the override file if it exists!
+dockerc               # -> docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
 
-dockerc -             # -> docker compose up -d
-dockerc - down        # -> docker compose down
-dockerc - exec app sh # -> docker compose exec app bash
+# Use "-" to use the default context with arguments.
+dockerc -             # -> docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+dockerc - down        # -> docker compose -f docker-compose.yml -f docker-compose.override.yml down
+dockerc - exec app sh # -> docker compose -f docker-compose.yml -f docker-compose.override.yml exec app bash
 
+# Use "--" to use docker compose without file arguments.
 dockerc --            # -> docker compose up -d
 dockerc -- start      # -> docker compose start
 
-# The dev context works in the same way as long as no matching file is found!
-dockerc dev           # -> docker compose up -d
-dockerc dev logs      # -> docker compose logs
+# The dev context works like the default context as long as no matching file is found.
+dockerc dev           # -> docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+dockerc dev logs      # -> docker compose -f docker-compose.yml -f docker-compose.override.yml logs
 
 dockerc prod          # -> docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 dockerc prod restart  # -> docker compose -f docker-compose.yml -f docker-compose.prod.yml restart

--- a/dockerc
+++ b/dockerc
@@ -39,10 +39,10 @@ else
 	ARGS=$@
 fi
 
-if [ ! -z "$first" ]; then
+# Check in current directory, then in docker directory
+while read -r dir; do
 
-	# Check in current directory, then in docker directory
-	while read -r dir; do
+	if [ ! -z "$first" ]; then
 
 		# Set compose file arguments
 		if [ -f "$dir/docker-compose-$first.yml" ]; then
@@ -64,21 +64,34 @@ if [ ! -z "$first" ]; then
 			fi
 		fi
 
-	done <<EOF
+	fi
+
+	if [ -z "$COMPOSE_FILE_ARGS" ] && [ "$dir" != "." ] && [ -f "$dir/docker-compose.yml" ] && \
+	   ([ -z "$first" ] || [ "$first" = "dev" ]);
+	then
+
+		if [ -f "$dir/docker-compose.override.yml" ]; then
+			COMPOSE_FILE_ARGS=" -f $dir/docker-compose.yml -f $dir/docker-compose.override.yml"
+
+		else
+			COMPOSE_FILE_ARGS=" -f $dir/docker-compose.yml"
+		fi
+
+	fi
+
+done <<EOF
 .
 ./docker
 EOF
 
-	# If compose file arguments are empty, unless the context is dev, exit with error
-	if [ -z "$COMPOSE_FILE_ARGS" ] && [ "$first" != "dev" ]; then
-		if [ -z "$second" ]; then
-			echo "Error: Unknown context '$first'"
-		else
-			echo "Error: Unknown context '$first-$second'"
-		fi
-		exit 1
+# If compose file arguments are empty, unless the context is dev, exit with error
+if [ -z "$COMPOSE_FILE_ARGS" ]; then
+	if [ -z "$second" ]; then
+		echo "Error: Unknown context '$first'"
+	else
+		echo "Error: Unknown context '$first-$second'"
 	fi
-
+	exit 1
 fi
 
 # Run docker compose


### PR DESCRIPTION
Default compose behavior is to use:
- `docker-compose.yml`, and
- `docker-compose.override.yml` if it exists

This PR reproduces this behavior and search in both `./` and `./docker` dirs for these files.

Therefore, this is now possible:
```sh
dockerc # -> docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
```