### PR TITLE
Fix to find default override config in current dir

### DIFF
--- a/dockerc
+++ b/dockerc
@@ -77,7 +77,7 @@ EOF
 
 		fi
 
-		if [ -z "$COMPOSE_FILE_ARGS" ] && [ "$dir" != "." ] && [ -f "$dir/docker-compose.yml" ] && \
+		if [ -z "$COMPOSE_FILE_ARGS" ] && [ -f "$dir/docker-compose.yml" ] && \
 		   ([ -z "$first" ] || [ "$first" = "dev" ]);
 		then
 
@@ -95,7 +95,7 @@ EOF
 ./docker
 EOF
 
-	# If compose file arguments are empty, unless the context is dev, exit with error
+	# If compose file arguments are empty, exit with error
 	if [ -z "$COMPOSE_FILE_ARGS" ]; then
 		if [ -z "$second" ]; then
 			echo "Error: Unknown context '$first'"


### PR DESCRIPTION
Fixes bug introduced in #10.

The program was only searching in the `docker/` subdir for the default context.
This fix restores search in the current dir for the default context.