### PR TITLE
Fix error for two or more args

### DIFF
--- a/dockerc
+++ b/dockerc
@@ -22,10 +22,8 @@ else
 fi
 
 # Other parameters are arguments passed to docker compose
-if [ ! -z "$@" ]; then
-	ARGS="$@"
-
-else
+ARGS="$@"
+if [ -z "$ARGS" ]; then
 	# If arguments are empty, set to the default arguments
 	ARGS="up -d"
 fi


### PR DESCRIPTION
- `dockerc - logs` worked fine.
- `dockerc - logs api` raised an error.